### PR TITLE
Added fuzzers to be run with OSS-Fuzz.

### DIFF
--- a/fuzz_decode.cc
+++ b/fuzz_decode.cc
@@ -1,0 +1,36 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <fstream>
+#include <sstream>
+
+#include <stdint.h>
+
+#include "jpeg_data.h"
+#include "jpeg_data_decoder.h"
+#include "jpeg_data_reader.h"
+
+using knusperli::JPEGData;
+using knusperli::JPEG_READ_ALL;
+using knusperli::ReadJpeg;
+
+extern "C" 
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	std::string input(reinterpret_cast<const char*>(data), size);
+	JPEGData jpg;
+	ReadJpeg(input, JPEG_READ_ALL, &jpg);
+
+	return 0;
+}


### PR DESCRIPTION
Hi maintainers,

It would be nice to have this project fuzzed by way of OSS-Fuzz, which is a service run by Google that performs continuous fuzzing of open source projects.

Over here: https://github.com/google/oss-fuzz/pull/5016 I have set up the necessary artifacts to get the project integrated. In that PR you also see the fuzzer attached, but it would be nicer to have the fuzzer integrated into the upstream project itself rather than keeping it in OSS-Fuzz - so if this PR gets merged I will remove it from OSS-Fuzz. For integration, the only thing we need email of the maintainers that will be receiving access to bug reports, coverage reports and similar.

If you have any questions you can ask me, but as this is a Google open source project I assume you can reach out internally to @inferno-chromium