### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 # Bazel build directories
-/bazel-bin/
-/bazel-genfiles/
-/bazel-knusperli/
-/bazel-out/
-/bazel-testlogs/
+/bazel*


### PR DESCRIPTION
`.gitignore` doesn't work at all because of trailing slashes, which is wrong because Bazel "directories" are actually symlinks and should be treated as files.
This PR simplifies the rule, too.