### PR TITLE
Fix "warning: control reaches end of non-void function" in decode.cc

### DIFF
--- a/decode.cc
+++ b/decode.cc
@@ -60,4 +60,6 @@ int main(int argc, char** argv) {
     printf("Failed to write png.\n");
     return 1;
   }
+
+  return 0;
 }


### PR DESCRIPTION
I discovered that there's no explicit `return` statement at the end of `int main()` function while moving from C++ to Rust in my fork. Bazel doesn't report this warning at all, even with `-Wall`.