### PR TITLE
Fix file opening on windows

### DIFF
--- a/decode.cc
+++ b/decode.cc
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::ifstream in_file(argv[1]);
+  std::ifstream in_file(argv[1], std::ifstream::binary);
   if (!in_file.good()) {
     printf("Failed to open input file.\n");
     return 1;


### PR DESCRIPTION
Today, I received the following email: 

> I'm just a hobbyist programmer, lacking the knowledge to properly join the github community. But you were the last to work on it, so here's a patch:

> decode.cc
std::ifstream in_file(argv[1]);
to
std::ifstream in_file(argv[1], std::ifstream::binary);

> There. Now the thing can cross-compile to Windows with mingw. Not explicitly specifying the file should open in binary was fine on linux. On windows the file opened but couldn't be read correctly.

> I did finally get the thing to run on Windows. Only took me four hours learning new and ever-more-obscure compiler flags. I'm annoyed and haven't got enough tea in me, so I'll be less rude later.

> Vyl Bird

---


I'm just transmitting the patch so that it isn't lost.