### PR TITLE
Migrate from WORKSPACE to MODULE.bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 # Bazel build directories
-/bazel-bin/
-/bazel-genfiles/
-/bazel-knusperli/
-/bazel-out/
-/bazel-testlogs/
+/bazel*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Bazel build directories
 /bazel*
+# Bazel lockfile
+/MODULE.bazel.lock

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,6 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+
+new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 new_git_repository(
     name = "lodepng",

--- a/lodepng.BUILD
+++ b/lodepng.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "lodepng",
     srcs = ["lodepng.cpp"],


### PR DESCRIPTION
This project fails to build with Bazel 9, showing following error messages:
```
ziemekz@ZiemekLaptop:~/knusperli$ bazel build :knusperli
Starting local Bazel server (9.0.0) and connecting to it...
... still trying to connect to local Bazel server (3307) after 10 seconds ...
WARNING: --enable_bzlmod is set, but no MODULE.bazel file was found at the workspace root. Bazel will create an empty MODULE.bazel file. Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel. For more details, please refer to https://github.com/bazelbuild/bazel/issues/18958.
ERROR: Traceback (most recent call last):
        File "/home/ziemekz/knusperli/BUILD", line 5, column 10, in <toplevel>
                cc_binary(
        File "/virtual_builtins_bzl/bazel/exports.bzl", line 40, column 9, in _removed_rule_failure
Error in fail:
         This rule has been removed from Bazel. Please add a `load()` statement for it.
         This can also be done automatically by running:
         buildifier --lint=fix <path-to-BUILD-or-bzl-file>

WARNING: Target pattern parsing failed.
ERROR: Skipping ':knusperli': no such target '//:knusperli': target 'knusperli' not declared in package '' defined by /home/ziemekz/knusperli/BUILD
ERROR: no such target '//:knusperli': target 'knusperli' not declared in package '' defined by /home/ziemekz/knusperli/BUILD
INFO: Elapsed time: 32.014s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```
Adding `--noenable_bzlmod` didn't help, so I decided it's about time to upgrade the config files to the latest recommendations. After these changes Knusperli compiles and runs properly.